### PR TITLE
Update chapter-05 exercise 44

### DIFF
--- a/solutions/chapter-05.md
+++ b/solutions/chapter-05.md
@@ -168,9 +168,9 @@
 ---
 44. Solution:
 	1. a.
-		1. x3001: 0000 001 0 0010 0111
-		2. x3002: 0000 100 0 0100 1110
-	2. Program never halts, it just endless setting 0 to R0 and increment one loop.
+		1. x3001: 0000 001 0 0011 1110  Offset9 = 000111110 = +62 → jumps to x3001+1+62 = x3040
+		2. x3002: 0000 100 0 0111 1101  Offset9 = 001111101 = +125 → jumps to x3002+1+125 = x3080
+	2. Program halts when R0 = x8000 = 1000 0000 0000 0000 which will be considered negative by BR instruction at x3002.
 ---
 45. PC put contents to MAR because it is how instruction loaded into LC-3. In this way we know which data where read or stored with, which operation. Microarchitecture increment PC to pointing to next instruction to read next instruction at next cycle.
 ---


### PR DESCRIPTION
You forgot about PC incremented in both cases when was evaluating branch offset. And in part a. you also forgot that x3040 and x3080 are hexadecimal. For example  x3040 = 0011 0000 0100 0000, so you should add decimal 62 to x3002 (x3001 +1 PC incremented) rather than 38. The same with x3080. In part b. you jump to x3001 from the x3002, rather than to x3000 due to PC incremented in x3002 (x3003 #- 2 = x3001). So R0 won't be set to zero again and loop won't be infinite.